### PR TITLE
Fix warnings from pytest 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
   - pypy
 
 install:
+  - pip install --upgrade pip
   - pip install --upgrade pytest
   - pip install coveralls
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
   - pypy
 
 install:
-  - pip install coveralls --use-wheel
+  - pip install coveralls
 
 script:
   - python setup.py develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
 
 script:
   - python setup.py develop
-  - coverage run --source=pytest_datafiles.py runtests.py
+  - coverage run --source=pytest_datafiles runtests.py
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - 2.7
   - 3.4
   - 3.5
+  - 3.6
   - pypy
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 
 language: python
 python:
-  - 2.6
   - 2.7
   - 3.4
   - 3.5
@@ -10,6 +9,7 @@ python:
   - pypy
 
 install:
+  - pip install --upgrade pytest
   - pip install coveralls
 
 script:

--- a/pytest_datafiles.py
+++ b/pytest_datafiles.py
@@ -66,16 +66,20 @@ def datafiles(request, tmpdir):
     pytest fixture to define a 'tmpdir' containing files or directories
     specified with a 'datafiles' mark.
     """
-    if 'datafiles' not in request.keywords:
-        return tmpdir
-    content = request.keywords.get('datafiles').args
+    content = []
     options = {
         'keep_top_dir': False,
         'on_duplicate': 'exception',  # ignore, overwrite
         }
-    options.update(request.keywords.get('datafiles').kwargs)
+    for mark in request.node.iter_markers('datafiles'):
+        content.extend(mark.args)
+        options.update(mark.kwargs)
     on_duplicate = options['on_duplicate']
     keep_top_dir = options['keep_top_dir']
+
+    if not content:
+        return tmpdir
+
     if keep_top_dir not in (True, False):
         raise ValueError("'keep_top_dir' must be True or False")
     if on_duplicate not in ('exception', 'ignore', 'overwrite'):

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def _read(fname):
 
 DEPENDENCIES = [
     'py',
-    'pytest',
+    'pytest>=3.6',
     ]
 
 DESCRIPTION = ("py.test plugin to create a 'tmpdir' containing predefined "
@@ -43,7 +43,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Topic :: Software Development :: Testing',
         ]
     )

--- a/tests/test_pytest_datafiles.py
+++ b/tests/test_pytest_datafiles.py
@@ -68,6 +68,19 @@ def test_multiple_files_str(datafiles):
     assert len((datafiles).listdir()) == 3
 
 
+@pytest.mark.datafiles(FIXTURE_FILES[0])
+@pytest.mark.datafiles(FIXTURE_FILES[1])
+@pytest.mark.datafiles(FIXTURE_FILES[2])
+def test_multiple_marks(datafiles):
+    """
+    Verify multiple marks are combined
+    """
+    assert (datafiles / 'huckleberry.txt').check(file=1)
+    assert (datafiles / 'random.bin').check(file=1)
+    assert (datafiles / 'sparrow.jpg').check(file=1)
+    assert len((datafiles).listdir()) == 3
+
+
 @pytest.mark.datafiles
 def test_no_files1(datafiles):
     """

--- a/tests/test_pytest_datafiles.py
+++ b/tests/test_pytest_datafiles.py
@@ -223,7 +223,6 @@ def test_on_duplicate_exception(testdir):
 
         @pytest.mark.datafiles(
             path.local(FIXTURE_DIR) / 'dir1',
-            path.local(FIXTURE_DIR) / 'dir2',
             path.local(FIXTURE_DIR) / 'dir3',
             )
         def test_ode(datafiles):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py34, py35
+envlist = py26, py27, py34, py35, py36
 
 [testenv]
 commands = py.test tests/test_pytest_datafiles.py

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py34, py35, py36
+envlist = py27, py34, py35, py36
 
 [testenv]
 commands = py.test tests/test_pytest_datafiles.py

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ basepython = python3
 deps =
     coverage
 commands =
-    coverage run --source=pytest_datafiles.py runtests.py
+    coverage run --source=pytest_datafiles runtests.py
     coverage html
 
 [testenv:lint]


### PR DESCRIPTION
This fixes #2.

I had to make a few other changes to fix up the build system, and added a test for some implicit behaviour of the existing code.

This version is not compatible with pytest versions before 3.6, which means it wont run on python 2.6. IMO this is a good thing, as python 2.6 is no longer receiving security patches. If you would rather keep compatibility then there's a commit that does that on my `misc_fixes_compat` branch.