### PR TITLE
Add test environments for Python 3.7 and 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ python:
   - 3.4
   - 3.5
   - 3.6
+  - 3.7
+  - 3.8
   - pypy
 
 install:

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,8 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Software Development :: Testing',
         ]
     )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36
+envlist = py27, py34, py35, py36, py37, py38
 
 [testenv]
 commands = py.test tests/test_pytest_datafiles.py


### PR DESCRIPTION
I have verified that the tests pass with both version of Python.

Personally, I have used pytest-datafiles in several Python 3.7 and 3.8 projects already. So I am reasonably confident it should work in the wild as well.