### PR TITLE
Explicitly register 'datafiles' marker to avoid pytest warnings

### DIFF
--- a/pytest_datafiles.py
+++ b/pytest_datafiles.py
@@ -6,6 +6,12 @@ from py import path  # pylint: disable=E0611
 import pytest
 
 
+def pytest_configure(config):
+    config.addinivalue_line(
+        'markers', 'datafiles(path): path to tmp data files'
+    )
+
+
 def _copy(src, target):
     """
     Copies a single entry (file, dir) named 'src' to 'target'. Softlinks are

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ DEPENDENCIES = [
     ]
 
 DESCRIPTION = ("py.test plugin to create a 'tmpdir' containing predefined "
-	       "files/directories.")
+               "files/directories.")
 LONG_DESCRIPTION = _read('README.rst') + '\n\n' + _read('CHANGELOG.rst')
 
 setup(
@@ -35,7 +35,7 @@ setup(
     long_description=LONG_DESCRIPTION,
     entry_points={
         'pytest11': ['pytest_datafiles = pytest_datafiles'],
-	},
+    },
     keywords='pytest datafiles tmpdir',
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
This is the same change as PR #9 that hasn't been merged for some reason, and became outdated in the meantime.