### PR TITLE
Add datafiles_root configuration value

### DIFF
--- a/pytest_datafiles.py
+++ b/pytest_datafiles.py
@@ -19,7 +19,7 @@ def _copy(src, target):
 
     if src.is_dir():
         shutil.copytree(src, target / src.name)
-    elif src.is_simlink():
+    elif src.is_symlink():
         os.symlink(os.readlink(src), target / src.name)
     else:  # file
         shutil.copy(src, target)


### PR DESCRIPTION
One can define datafiles_root in pytest configuration file
to define the datafiles root directory.

This feature allows to define a common root folder instead
of defining the FIXTURE_DIR on each test.